### PR TITLE
Fixed NSDictionary+Subscript to use `objectForKey:`

### DIFF
--- a/NSDictionary+Subscript.m
+++ b/NSDictionary+Subscript.m
@@ -14,7 +14,7 @@
 
 -(id)objectForKeyedSubscript:(id)key
 {
-    return [self valueForKey:key];
+    return [self objectForKey:key];
 }
 
 @end


### PR DESCRIPTION
NSDictionary+Subscript was using the KVC method `valueForKey:` for its `objectForKeyedSubscript:` method instead of the NSDictionary method `objectForKey:`.  Switched to use `objectForKey:`.

Resolves paneidos/objective-c-subscript#5
